### PR TITLE
Add github repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   },
   "keywords": [],
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nicojs/node-link-parent-bin.git"
+  },
   "license": "ISC",
   "devDependencies": {
     "@types/chai": "^3.4.35",


### PR DESCRIPTION
This PR adds a "repository" field to package.json so that https://www.npmjs.com/package/link-parent-bin links back to the source code. 