### PR TITLE
Support for binaries defined as string rather than object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ node_modules
 *.d.ts
 *.map
 *.log
+
+# IntelliJ project files
+.idea
+*.iml

--- a/sample/dependencies/hello-dev-dependency/package.json
+++ b/sample/dependencies/hello-dev-dependency/package.json
@@ -1,7 +1,5 @@
 {
     "name": "hello-dev-dependency",
     "version": "0.0.0",
-    "bin": {
-        "helloDevDependency": "hello-dev-dependency"
-    }
+    "bin": "hello-dev-dependency"
 }

--- a/sample/dependencies/hello-dev-dependency/package.json
+++ b/sample/dependencies/hello-dev-dependency/package.json
@@ -1,5 +1,7 @@
 {
     "name": "hello-dev-dependency",
     "version": "0.0.0",
-    "bin": "hello-dev-dependency"
+    "bin": {
+        "helloDevDependency": "hello-dev-dependency"
+    }
 }

--- a/sample/dependencies/hello-single-binary-dependency/hello-single-binary-dependency
+++ b/sample/dependencies/hello-single-binary-dependency/hello-single-binary-dependency
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+console.log('hello single-binary-dependency');

--- a/sample/dependencies/hello-single-binary-dependency/package.json
+++ b/sample/dependencies/hello-single-binary-dependency/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "hello-single-binary-dependency",
+    "version": "0.0.0",
+    "bin": "hello-single-binary-dependency"
+}

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -10,6 +10,9 @@
         "hello-dev-dependency": {
             "version": "file:dependencies/hello-dev-dependency",
             "dev": true
+        },
+        "hello-single-binary-dependency": {
+            "version": "file:dependencies/hello-single-binary-dependency"
         }
     }
 }

--- a/sample/package.json
+++ b/sample/package.json
@@ -10,7 +10,8 @@
         "hello-dev-dependency": "file:./dependencies/hello-dev-dependency"
     },
     "dependencies": {
-        "hello-dependency": "file:./dependencies/hello-dependency"
+        "hello-dependency": "file:./dependencies/hello-dependency",
+        "hello-single-binary-dependency": "file:./dependencies/hello-single-binary-dependency"
     },
     "localDependencies": {
         "link-parent-bin": ".."

--- a/sample/packages/child-1/package.json
+++ b/sample/packages/child-1/package.json
@@ -5,6 +5,7 @@
     "scripts": {
         "hello-dependency": "helloDependency",
         "hello-dev-dependency": "helloDevDependency",
+        "hello-single-binary-dependency": "hello-single-binary-dependency",
         "link-parent-bin-help": "link-parent-bin --help"
     }
 }

--- a/test/integration/sample.spec.ts
+++ b/test/integration/sample.spec.ts
@@ -49,4 +49,8 @@ describe('Sample project after installing and linking with `link-parent-bin`', f
     it('should be able to run a linked local dependency', () => {
         return expect(execInSample('npm run link-parent-bin-help', 'packages/child-1')).to.eventually.have.property('stdout').and.match(/Usage: link-parent-bin/g);
     });
+
+    it('should be able to run a dependency with a single binary', () => {
+        return expect(execInSample('npm run hello-single-binary-dependency', 'packages/child-1')).to.eventually.have.property('stdout').and.match(/hello single-binary-dependency/g);
+    });
 })

--- a/test/unit/ParentBinLinker.spec.ts
+++ b/test/unit/ParentBinLinker.spec.ts
@@ -10,7 +10,6 @@ import { ParentBinLinker, PackageJson } from './../../src/ParentBinLinker';
 describe('ParentBinLinker', () => {
 
     let sandbox: sinon.SinonSandbox;
-    let statStub: sinon.SinonStub;
     let readFileStub: sinon.SinonStub;
     let linkStub: sinon.SinonStub;
     let readDirsStub: sinon.SinonStub;
@@ -27,7 +26,6 @@ describe('ParentBinLinker', () => {
             childDirectoryRoot: 'packages'
         };
         sut = new ParentBinLinker(options);
-        statStub = sandbox.stub(fs, 'stat');
         readDirsStub = sandbox.stub(FSUtils, 'readDirs');
         readFileStub = sandbox.stub(fs, 'readFile');
         linkStub = sandbox.stub(link, 'link');


### PR DESCRIPTION
Hey @nicojs! I came across a compatibility issue between link-parent-bin and rimraf as rimraf defines its binary as string rather than object.

This PR fixes this issue.

As always, thanks for your awesome work :-)

Best,
Jan