### PR TITLE
feat: support log level off

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,7 +114,7 @@ $ node_modules/.bin/link-parent-bin --help
     -d, --link-dev-dependencies <true|false>      Enables linking of parents `devDependencies`. Defaults to: true
     -s, --link-dependencies <true|false>          Enables linking of parents `dependencies`. Defaults to: false
     -o, --link-local-dependencies <true|false>    Enables linking of parents `localDependencies`. Defaults to: false
-    -l, --log-level <debug|info|error>            Set the log level
+    -l, --log-level <debug|info|error|off>        Set the log level
 ```
 
 ## Use programmatically

--- a/src/program.ts
+++ b/src/program.ts
@@ -20,7 +20,7 @@ export const program = {
             .option('-d, --link-dev-dependencies <true|false>', describeLinking('devDependencies', true), parseBoolean, true)
             .option('-s, --link-dependencies <true|false>', describeLinking('dependencies', false), parseBoolean, false)
             .option('-o, --link-local-dependencies <true|false>', describeLinking('localDependencies', false), parseBoolean, false)
-            .option('-l, --log-level <debug|info|error>', 'Set the log level', /debug|info|error/, 'info')
+            .option('-l, --log-level <debug|info|error|off>', 'Set the log level', /debug|info|error|off/, 'info')
             .parse(argv) as any;
     }
 } 


### PR DESCRIPTION
We can ignore EEXIST 'errors' which does not cause terminal exist, that look like real errors on CI/Linux/macOS platform.