### PR TITLE
fix: Update cmd-shim package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -311,6 +311,11 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://pkgs.dev.azure.com/flinthills/_packaging/NPM_FHR/npm/registry/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs="
+    },
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -323,12 +328,12 @@
       }
     },
     "cmd-shim": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-      "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/flinthills/_packaging/NPM_FHR/npm/registry/cmd-shim/-/cmd-shim-4.0.1.tgz",
+      "integrity": "sha1-iFOBLNcDP65rridj0nISMfx4RCQ=",
       "requires": {
         "graceful-fs": "^4.1.2",
-        "mkdirp": "~0.5.0"
+        "mkdirp-infer-owner": "^1.0.2"
       }
     },
     "code-point-at": {
@@ -1215,6 +1220,11 @@
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/flinthills/_packaging/NPM_FHR/npm/registry/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1590,6 +1600,23 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mkdirp-infer-owner": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/flinthills/_packaging/NPM_FHR/npm/registry/mkdirp-infer-owner/-/mkdirp-infer-owner-1.0.2.tgz",
+      "integrity": "sha1-kVXUteD4moNUVdfbro87uj0vp3w=",
+      "requires": {
+        "chownr": "^1.1.3",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^1.0.3"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://pkgs.dev.azure.com/flinthills/_packaging/NPM_FHR/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34="
+        }
       }
     },
     "mocha": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^3.5.2"
   },
   "dependencies": {
-    "cmd-shim": "^2.0.2",
+    "cmd-shim": "~4.0.1",
     "commander": "^2.20.0",
     "log4js": "^4.4.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Fix for issue #20. Updated the `cmd-shim` package and that causes the correct exit code handling to be emitted in the various files.


Before :
``` cmd
@SETLOCAL

@IF EXIST "%~dp0\node.exe" (
  @SET "_prog=%~dp0\node.exe"
) ELSE (
  @SET "_prog=node"
  @SET PATHEXT=%PATHEXT:;.JS;=;%
)

"%_prog%"  "%~dp0\..\..\..\..\node_modules\hello-single-binary-dependency\hello-single-binary-dependency" %*
@ENDLOCAL
```

 #After:

``` cmd
@ECHO off
SETLOCAL
CALL :find_dp0

IF EXIST "%dp0%\node.exe" (
  SET "_prog=%dp0%\node.exe"
) ELSE (
  SET "_prog=node"
  SET PATHEXT=%PATHEXT:;.JS;=;%
)

"%_prog%"  "%dp0%\..\..\..\..\node_modules\hello-single-binary-dependency\hello-single-binary-dependency" %*
ENDLOCAL
EXIT /b %errorlevel%
:find_dp0
SET dp0=%~dp0
EXIT /b

```