### PR TITLE
feat(log): log a summary

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,49 +1,55 @@
 {
-    // Use IntelliSense to learn about possible Node.js debug attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-      {
-        "name": "Attach",
-        "port": 9229,
-        "request": "attach",
-        "skipFiles": [
-          "<node_internals>/**"
-        ],
-        "type": "pwa-node"
-      },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Unit Tests",
-            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-            "args": [
-                "--no-timeouts",
-                "--colors",
-                "${workspaceRoot}/dist/test/unit/*.js"
-            ],
-            "internalConsoleOptions": "openOnSessionStart",
-            "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/dist/**/*.js"
-            ]
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Integration Tests",
-            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-            "args": [
-                "--no-timeouts",
-                "--colors",
-                "${workspaceRoot}/dist/test/integration/*.js"
-            ],
-            "internalConsoleOptions": "openOnSessionStart",
-            "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/dist/**/*.js"
-            ]
-        }
-    ]
+  // Use IntelliSense to learn about possible Node.js debug attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "pwa-node"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Unit Tests",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--no-timeouts",
+        "--colors",
+        "${workspaceRoot}/dist/test/unit/*.js"
+      ],
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/dist/**/*.js"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Integration Tests",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--no-timeouts",
+        "--colors",
+        "${workspaceRoot}/dist/test/integration/*.js"
+      ],
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/dist/**/*.js"
+      ]
+    }
+  ]
 }

--- a/src/link.ts
+++ b/src/link.ts
@@ -5,15 +5,28 @@ import { promises as fs } from 'fs';
 import { FSUtils } from './FSUtils';
 import cmdShim from 'cmd-shim';
 
-async function symlink(from: string, to: string) {
+export type LinkStatus =
+  | 'success'
+  | 'alreadyExists'
+  | 'differentLinkAlreadyExists'
+  | 'error';
+
+export interface LinkResult {
+  status: LinkStatus;
+}
+
+async function symlink(from: string, to: string): Promise<LinkResult> {
   to = path.resolve(to);
   const toDir = path.dirname(to);
   const target = path.relative(toDir, from);
   await FSUtils.mkdirp(path.dirname(to));
-  return await fs.symlink(target, to, 'junction');
+  await fs.symlink(target, to, 'junction');
+  return {
+    status: 'success',
+  };
 }
 
-export async function link(from: string, to: string): Promise<void> {
+export async function link(from: string, to: string): Promise<LinkResult> {
   if (platform() === 'win32') {
     return cmdShimIfExists(from, to);
   } else {
@@ -21,25 +34,26 @@ export async function link(from: string, to: string): Promise<void> {
   }
 }
 
-async function cmdShimIfExists(from: string, to: string): Promise<void> {
+async function cmdShimIfExists(from: string, to: string): Promise<LinkResult> {
   try {
     await fs.stat(to);
-    info(`Link at '${to}' already exists. Leaving it alone.`);
+    debug(`Link at '${to}' already exists. Leaving it alone.`);
+    return { status: 'alreadyExists' };
   } catch (_) {
     /* link doesn't exist */
-    return new Promise<void>((res, rej) => {
+    return new Promise<LinkResult>((res, rej) => {
       cmdShim.ifExists(from, to, (err: unknown) => {
         if (err) {
           rej(err);
         } else {
-          res(undefined);
+          res({ status: 'success' });
         }
       });
     });
   }
 }
 
-async function linkIfExists(from: string, to: string): Promise<void> {
+async function linkIfExists(from: string, to: string): Promise<LinkResult> {
   try {
     await fs.stat(from);
     const fromOnDisk = await fs.readlink(to);
@@ -47,16 +61,24 @@ async function linkIfExists(from: string, to: string): Promise<void> {
     const absoluteFrom = path.resolve(toDir, from);
     const absoluteFromOnDisk = path.resolve(toDir, fromOnDisk);
     if (absoluteFrom !== absoluteFromOnDisk) {
-      info(
-        `Different link at '${to}' already exists. Leaving it alone, the package is probably already installed in the child package.`,
+      debug(
+        `Different link at '${to}' to '${absoluteFromOnDisk}' already exists. Leaving it alone, the package is probably already installed in the child package.`,
       );
+      return {
+        status: 'differentLinkAlreadyExists',
+      };
+    } else {
+      debug(`Link at '${to}' already exists.`);
+      return {
+        status: 'alreadyExists',
+      };
     }
   } catch {
     return symlink(from, to);
   }
 }
 
-function info(message: string, ...args: unknown[]) {
+function debug(message: string, ...args: unknown[]) {
   const log = getLogger('link');
-  log.info(message, ...args);
+  log.debug(message, ...args);
 }

--- a/test/helpers/createLogStub.ts
+++ b/test/helpers/createLogStub.ts
@@ -1,0 +1,20 @@
+import sinon from 'sinon';
+import { Logger } from 'log4js';
+
+export function createLoggerMock(): sinon.SinonStubbedInstance<Logger> {
+  return {
+    debug: sinon.stub(),
+    error: sinon.stub(),
+    fatal: sinon.stub(),
+    info: sinon.stub(),
+    isDebugEnabled: sinon.stub(),
+    isErrorEnabled: sinon.stub(),
+    isFatalEnabled: sinon.stub(),
+    isInfoEnabled: sinon.stub(),
+    clearContext: sinon.stub(),
+    isLevelEnabled: sinon.stub(),
+    isTraceEnabled: sinon.stub(),
+    isWarnEnabled: sinon.stub(),
+    log: sinon.stub(),
+  } as sinon.SinonStubbedInstance<Logger>;
+}


### PR DESCRIPTION
Log a summary when done. Don't log details to info. Example: 
`INFO ParentBinLinker Symlinked 0 bin(s) (319 link(s) already exists, 4 different link(s) already exists, 0 error(s)). Run with debug log level for more info.`
